### PR TITLE
Removed state-store execution and tiller ns install

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -26,8 +26,6 @@ phases:
     commands:
       - "mkdir ~/.kube/"
       - "aws s3 cp s3://non-production-cluster-keystore/kubecfg.yaml ~/.kube/config" 
-      - "export KOPS_STATE_STORE=s3://moj-cp-k8s-investigation-kops"
-      - "kops export kubecfg non-production.k8s.integration.dsd.io"
   build:
     commands:
       - "kubectl config get-contexts"
@@ -39,7 +37,7 @@ phases:
 
   post_build:
     commands:
-       - "ls namespaces/ | while read file; do helm init --service-account $file-tiller --tiller-namespace $file; done"
+#       - "ls namespaces/ | while read file; do helm init --service-account $file-tiller --tiller-namespace $file; done"
 
 #artifacts:
   #files:


### PR DESCRIPTION
As Kuberos install is now fixed, I have removed the state import from s3 as this is no longer required. 