### PR TITLE
Amend compute resources and object counts

### DIFF
--- a/namespaces/laa-fee-calculator-dev/compute-resources.yaml
+++ b/namespaces/laa-fee-calculator-dev/compute-resources.yaml
@@ -1,11 +1,11 @@
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  name: compute-resources
-spec:
-  hard:
-    pods: "4"
-    requests.cpu: "1"
-    requests.memory: 1Gi
-    limits.cpu: "2"
-    limits.memory: 2Gi
+# apiVersion: v1
+# kind: ResourceQuota
+# metadata:
+#   name: compute-resources
+# spec:
+#   hard:
+#     pods: "4"
+#     requests.cpu: "1"
+#     requests.memory: 1Gi
+#     limits.cpu: "2"
+#     limits.memory: 2Gi

--- a/namespaces/laa-fee-calculator-dev/object-counts.yaml
+++ b/namespaces/laa-fee-calculator-dev/object-counts.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  name: object-counts
-spec:
-  hard:
-    configmaps: "10"
-    persistentvolumeclaims: "4"
-    replicationcontrollers: "20"
-    secrets: "10"
-    services: "10"
-    services.loadbalancers: "2"
+# apiVersion: v1
+# kind: ResourceQuota
+# metadata:
+#   name: object-counts
+# spec:
+#   hard:
+#     configmaps: "10"
+#     persistentvolumeclaims: "4"
+#     replicationcontrollers: "20"
+#     secrets: "10"
+#     services: "10"
+#     services.loadbalancers: "2"

--- a/namespaces/mps-dev/compute-resources.yaml
+++ b/namespaces/mps-dev/compute-resources.yaml
@@ -1,11 +1,11 @@
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  name: compute-resources
-spec:
-  hard:
-    pods: "4"
-    requests.cpu: "1"
-    requests.memory: 1Gi
-    limits.cpu: "2"
-    limits.memory: 2Gi
+# apiVersion: v1
+# kind: ResourceQuota
+# metadata:
+#   name: compute-resources
+# spec:
+#   hard:
+#     pods: "4"
+#     requests.cpu: "1"
+#     requests.memory: 1Gi
+#     limits.cpu: "2"
+#     limits.memory: 2Gi

--- a/namespaces/mps-dev/object-counts.yaml
+++ b/namespaces/mps-dev/object-counts.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  name: object-counts
-spec:
-  hard:
-    configmaps: "10"
-    persistentvolumeclaims: "4"
-    replicationcontrollers: "20"
-    secrets: "10"
-    services: "10"
-    services.loadbalancers: "2"
+# apiVersion: v1
+# kind: ResourceQuota
+# metadata:
+#   name: object-counts
+# spec:
+#   hard:
+#     configmaps: "10"
+#     persistentvolumeclaims: "4"
+#     replicationcontrollers: "20"
+#     secrets: "10"
+#     services: "10"
+#     services.loadbalancers: "2"

--- a/namespaces/pvbpublic-dev/compute-resources.yaml
+++ b/namespaces/pvbpublic-dev/compute-resources.yaml
@@ -1,11 +1,11 @@
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  name: compute-resources
-spec:
-  hard:
-    pods: "4"
-    requests.cpu: "1"
-    requests.memory: 1Gi
-    limits.cpu: "2"
-    limits.memory: 2Gi
+# apiVersion: v1
+# kind: ResourceQuota
+# metadata:
+#   name: compute-resources
+# spec:
+#   hard:
+#     pods: "4"
+#     requests.cpu: "1"
+#     requests.memory: 1Gi
+#     limits.cpu: "2"
+#     limits.memory: 2Gi

--- a/namespaces/pvbpublic-dev/object-counts.yaml
+++ b/namespaces/pvbpublic-dev/object-counts.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  name: object-counts
-spec:
-  hard:
-    configmaps: "10"
-    persistentvolumeclaims: "4"
-    replicationcontrollers: "20"
-    secrets: "10"
-    services: "10"
-    services.loadbalancers: "2"
+# apiVersion: v1
+# kind: ResourceQuota
+# metadata:
+#   name: object-counts
+# spec:
+#   hard:
+#     configmaps: "10"
+#     persistentvolumeclaims: "4"
+#     replicationcontrollers: "20"
+#     secrets: "10"
+#     services: "10"
+#     services.loadbalancers: "2"


### PR DESCRIPTION
- Commented out all resourecequota in a namespace to prevent user from specifying cpu and memory range at every deployment. 
- Can uncomment and use resourcequota at a later stage 