### PR TITLE
Add an environment for testing documentation

### DIFF
--- a/kalbirs-app-dev/kalbirs-app-dev-admin-role.yaml
+++ b/kalbirs-app-dev/kalbirs-app-dev-admin-role.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kalbirs-app-dev-admins
+  namespace: kalbirs-app-dev
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kalbirs-app-dev/namespace.yaml
+++ b/kalbirs-app-dev/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1 
+kind: Namespace 
+metadata:
+      name: kalbirs-app-dev
+      labels:
+           name: kalbirs-app-dev


### PR DESCRIPTION
@kalbir is testing the documentation on how to create
new non-production environmnents in kubernetes as part of
ticket CPT-305. To do that I need to create a new environment
-- the documentation says to add these two files to make that
happen.