### PR TITLE
Add service account for circleci 

### DIFF
--- a/namespaces/laa-fee-calculator-dev/serviceaccount-circleci.yaml
+++ b/namespaces/laa-fee-calculator-dev/serviceaccount-circleci.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: laa-fee-calculator-dev
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-fee-calculator-dev
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: laa-fee-calculator-dev
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+apiGroup: rbac.authorization.k8s.io

--- a/namespaces/mps-dev/serviceaccount-circleci.yaml
+++ b/namespaces/mps-dev/serviceaccount-circleci.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: mps-dev
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: mps-dev
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: mps-dev
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+apiGroup: rbac.authorization.k8s.io

--- a/namespaces/pvbpublic-dev/serviceaccount-circleci.yaml
+++ b/namespaces/pvbpublic-dev/serviceaccount-circleci.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: pvbpublic-dev
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: pvbpublic-dev
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: pvbpublic-dev
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This PR is in relation to ticket 25 on waffle.io - https://waffle.io/ministryofjustice/cloud-platform/cards/5af5ba15bf45ab001cdef897

**Background** 
In order for CircleCI to run commands in a kubernetes cluster, it needs access to the cluster. By creating a service account in the cluster, it generates a secret token that can be added to CircleCI. Circle will now be able to authenticate against the cluster.

**PR**
A new service account will be deployed in each namespace if CircleCI is required for the application. For testing purposes, service accounts have been applied to every namespace.

In the yaml, CircleCI has been given permissions to do anything within the namespace specified. I imagine we may want to restrict this as much as possible in the future. 

_Note:_ 
cluster-admin - Allows super-user access to perform any action on any resource. When used in a ClusterRoleBinding, it gives full control over every resource in the cluster and in all namespaces. When used in a RoleBinding, it gives full control over every resource in the rolebinding's namespace, including the namespace itself. Reference - https://kubernetes.io/docs/admin/authorization/rbac/



