### PR TITLE
Add environment for testing the docs

### DIFF
--- a/namespaces/documentation-test/namespace.yaml
+++ b/namespaces/documentation-test/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: documentation-test
+  labels:
+    name: documentation-test

--- a/namespaces/documentation-test/rbac-config-tiller.yaml
+++ b/namespaces/documentation-test/rbac-config-tiller.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: documentation-test
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: tiller
+  namespace: documentation-test
+subjects:
+- kind: ServiceAccount
+  name: tiller
+  namespace: documentation-test
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
When trying out the documentation for e.g. deploying an app you usually
need an environment to work in. I am going to create this one to test
specifically [this pull
request](https://github.com/ministryofjustice/cloud-platform-user-docs/pull/36).

I'll probably delete it afterwards to tidy up.