### PR TITLE
Fixed CircleCI ServiceAccount RBAC Policy

### DIFF
--- a/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
+++ b/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
@@ -33,7 +33,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: circleci
-  namespace: cloudplatformsp-reference-app
+  namespace: cloudplatforms-reference-app
 roleRef:
   kind: Role
   name: circleci


### PR DESCRIPTION
The service account for CircleCI has an RBAC policy to allow Circle to run helm commands in the non-production cluster. Unfortunately, a small spelling error prevented circle running any commands at all. The namespace was spelt incorrectly meaning that it was trying to find a circleci service account in the namespace 'cloudplatformsp-reference-app'. This issue has been fixed in this PR. 

connects to #25 and #23 in ministryofjustice/cloud-platform-reference-app

https://github.com/ministryofjustice/cloud-platform-reference-app/issues/25
https://github.com/ministryofjustice/cloud-platform-reference-app/issues/23

