### PR TITLE
 Allow CircleCI to create deployments in non-production cluster 

### DIFF
--- a/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
+++ b/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
@@ -21,6 +21,7 @@ rules:
       - ""
     resources:
       - "pods/portforward"
+      - "deployments"
     verbs:
       - "create"
 

--- a/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
+++ b/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
@@ -21,6 +21,11 @@ rules:
       - ""
     resources:
       - "pods/portforward"
+    verbs:
+      - "create"
+  - apiGroups:
+      - "extensions"
+    resources:
       - "deployments"
     verbs:
       - "create"


### PR DESCRIPTION
**Summary** 
The RBAC Policy for CircleCI to interact with the kubernetes cluster has been set up with limited permissions. When executing helm commands, the client version and the server version are incompatible 'Error: incompatible versions client[v2.9.1] server[v2.8.2]' 

To fix the above issue, a helm init --upgrade is required in the tiller namespace 'cloudplatforms-reference-app'. However, the below error occurs when executing the command. 

Error: error installing: deployments.extensions is forbidden: User "system:serviceaccount:cloudplatforms-reference-app:circleci" cannot create deployments.extensions in the namespace "cloudplatforms-reference-app"

To fix the issue, the 'deployments' resource has been added to the verb 'create'. The error suggests that we can restrict the rules even further and change the apiGroups to 'extensions'. This has been applied to the PR.

connects to issue #25 and #23 in ministryofjustice/cloud-platform-reference-app

ministryofjustice/cloud-platform-reference-app#25
ministryofjustice/cloud-platform-reference-app#23

