### PR TITLE
Amend CircleCI ServiceAccount RBAC Policy

### DIFF
--- a/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
+++ b/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
@@ -21,6 +21,7 @@ rules:
       - ""
     resources:
       - "pods/portforward"
+      - "deployments"
     verbs:
       - "create"
 

--- a/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
+++ b/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
@@ -21,6 +21,11 @@ rules:
       - ""
     resources:
       - "pods/portforward"
+    verbs:
+      - "create"
+  - apiGroups:
+      - "extensions"
+    resources:
       - "deployments"
     verbs:
       - "create"

--- a/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
+++ b/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
@@ -21,14 +21,12 @@ rules:
       - ""
     resources:
       - "pods/portforward"
+      - "deployment"
+      - "jobs"
     verbs:
       - "create"
-  - apiGroups:
-      - "extensions"
-    resources:
-      - "deployments"
-    verbs:
-      - "create"
+      - "delete"
+      - "get"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
**WHAT**
Allowed CircleCI account to delete deployments, get deployments, delete jobs and get jobs. 

**WHY** 
As part of the CircleCI build, Circle needs to create a new deployment and delete jobs. This is particularly useful when redeploying the job migration for cloud-platform-reference-app.

