### PR TITLE
Fix: Namechange on form-builder GH group 

### DIFF
--- a/namespaces/formbuilder-services-dev/formbuilder-services-dev-admin-role.yaml
+++ b/namespaces/formbuilder-services-dev/formbuilder-services-dev-admin-role.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: formbuilder-services-dev
 subjects:
   - kind: Group
-    name: "github:$form-builder"
+    name: "github:form-builder"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Really small change to fix a typo on the name creation. This was previously set as a $form-builder. 