### PR TITLE
Amend CircleCI Service Account Role

### DIFF
--- a/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
+++ b/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
@@ -17,16 +17,16 @@ rules:
       - "pods"
     verbs:
       - "list"
+      - "create"
+      - "delete"
   - apiGroups:
       - ""
     resources:
       - "pods/portforward"
       - "deployment"
-      - "jobs"
     verbs:
       - "create"
       - "delete"
-      - "get"
 
 ---
 kind: RoleBinding

--- a/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
+++ b/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
@@ -38,7 +38,6 @@ rules:
       - "delete"
       - "create"
 
-
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
+++ b/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
@@ -34,6 +34,9 @@ rules:
       - "jobs"
     verbs:
       - "get"
+      - "update"
+      - "delete"
+      - "create"
 
 
 ---

--- a/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
+++ b/namespaces/cloudplatforms-reference-app/serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "list"
       - "create"
       - "delete"
+      - "get"
   - apiGroups:
       - ""
     resources:
@@ -27,6 +28,13 @@ rules:
     verbs:
       - "create"
       - "delete"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+    verbs:
+      - "get"
+
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
**WHAT**

1) Extended permissions to allow CircleCI to delete, create and update jobs in the apiGroup "batch".
2) Extended permissions to allow CircleCI to get, delete and create pods.

**WHY**
1) The helm upgrade requires to create new deployments and delete deployments. Circle will require those permissions. 
2) In order to delete the db-migration job during the build, Circle needs the permissions to create, delete and update.